### PR TITLE
Fixed fatal error when building with catkin

### DIFF
--- a/rb1_base_pad/CMakeLists.txt
+++ b/rb1_base_pad/CMakeLists.txt
@@ -6,6 +6,7 @@ find_package(catkin REQUIRED COMPONENTS
   message_generation
   geometry_msgs
   robotnik_msgs
+  rb1_base_msgs
   roscpp
   sensor_msgs
   diagnostic_updater

--- a/rb1_base_pad/package.xml
+++ b/rb1_base_pad/package.xml
@@ -17,6 +17,7 @@
   <buildtool_depend>catkin</buildtool_depend>
   <build_depend>geometry_msgs</build_depend>
   <build_depend>robotnik_msgs</build_depend>
+  <build_depend>rb1_base_msgs</build_depend>
   <build_depend>roscpp</build_depend>
   <build_depend>sensor_msgs</build_depend>
   <build_depend>message_generation</build_depend>
@@ -24,6 +25,7 @@
 
   <run_depend>geometry_msgs</run_depend>
   <run_depend>robotnik_msgs</run_depend>
+  <run_depend>rb1_base_msgs</run_depend>
   <run_depend>roscpp</run_depend>
   <run_depend>sensor_msgs</run_depend>
   <run_depend>message_runtime</run_depend>


### PR DESCRIPTION
Fixed fatal error: rb1_base_msgs/SetElevator.h: No such file or directory. Solved by adding **rb1_base_msgs** dependency.