### PR TITLE
Map Saver and Move Base improvement

### DIFF
--- a/rb1_base_localization/launch/map_saver.launch
+++ b/rb1_base_localization/launch/map_saver.launch
@@ -1,0 +1,12 @@
+<?xml version="1.0"?>
+<launch>
+        <!-- maps inside the folder summit_xl_navigation/maps -->
+	<arg name="map_name" default="map"/>
+	<arg name="map_topic" default="map"/>
+	<arg name="destination_folder" default="$(optenv HOME /home/summit)"/>
+	<!-- Run the map server -->
+	<node name="map_saver_node" pkg="map_server" type="map_saver" args="-f $(arg destination_folder)/$(arg map_name)">
+		<remap from="map" to="$(arg map_topic)"/>
+	</node>
+
+</launch>

--- a/rb1_base_navigation/launch/move_base_teb.launch
+++ b/rb1_base_navigation/launch/move_base_teb.launch
@@ -18,7 +18,7 @@
 
 
   <!-- Run move_base -->
-  <node pkg="move_base" type="move_base" respawn="false" name="move_base">
+  <node pkg="move_base" type="move_base" respawn="false" name="move_base" output="screen">
     <remap from="cmd_vel" to="$(arg cmd_vel_topic)" />
     <remap from="odom" to="$(arg odom_topic)" />
 


### PR DESCRIPTION
## Identify the Bug/Problem
The robot's documentation has an option to save the generated map by executing a launch file. However, this file didn't exist.
Besides, move_base is not logging anything.

## Description of the Change
I have added the `map_saver.launch` file and it can be used like this: 
- `ROS_NAMESPACE=robot roslaunch rb1_base_localization map_saver.launch`
- `ROS_NAMESPACE=robot roslaunch rb1_base_localization map_saver.launch map_name:=my_map destination_folder:=/path/to/map/folder`

On the other hand, I have added the `output=screen` option in move_base in order to see the node's log